### PR TITLE
add ability to specify offsets for consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $ protokaf consume HelloRequest -G mygroup -t test -o 5
 
 **Read from offset `5` messages from `test` topic and from offset `10` from `anothertest` topic**
 ```sh
-$ protokaf consume HelloRequest -G mygroup -t test -o test:5,anothertest:10
+$ protokaf consume HelloRequest -G mygroup -t test,anothertest -o test:5,anothertest:10
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -157,11 +157,6 @@ $ protokaf consume HelloRequest -G mygroup -t test -c 10
 $ protokaf consume HelloRequest -G mygroup -t test -o 5
 ```
 
-**Read from offset `5` messages from `test` topic and from offset `10` from `anothertest` topic**
-```sh
-$ protokaf consume HelloRequest -G mygroup -t test,anothertest -o test:5,anothertest:10
-```
-
 ## Testing
 
 ### Prepare test environment

--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ $ protokaf consume HelloRequest -G mygroup -t test
 $ protokaf consume HelloRequest -G mygroup -t test -c 10
 ```
 
+**Read from offset `5` messages from `test` topic**
+```sh
+$ protokaf consume HelloRequest -G mygroup -t test -o 5
+```
+
+**Read from offset `5` messages from `test` topic and from offset `10` from `anothertest` topic**
+```sh
+$ protokaf consume HelloRequest -G mygroup -t test -o test:5,anothertest:10
+```
+
 ## Testing
 
 ### Prepare test environment

--- a/cmd/cmd_consume.go
+++ b/cmd/cmd_consume.go
@@ -12,11 +12,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"strconv"
-	"strings"
 	"sync"
 )
 
-var ErrInvalidOffset = errors.New("invalid offset format")
+var (
+	ErrInvalidOffset = errors.New("invalid offset format")
+	ErrOffsetNotSet  = errors.New("offset not set")
+)
 
 func NewConsumeCmd() *cobra.Command {
 	var (
@@ -24,7 +26,7 @@ func NewConsumeCmd() *cobra.Command {
 		topicsFlag []string
 		countFlag  int
 		noCommit   bool
-		offsets    []string
+		offset     string
 	)
 
 	cmd := &cobra.Command{
@@ -65,22 +67,18 @@ func NewConsumeCmd() *cobra.Command {
 				handler := &protoHandler{
 					MaxCount: countFlag,
 					desc:     md,
-
-					topics:    topicsFlag,
-					partition: int32(0),
+					topic:    topicsFlag[0],
 				}
 
 				// set offset
-				if offsets != nil {
-					offsetsArg, err := parseOffsetsFlag(offsets)
-					if err != nil {
-						log.Errorf("Failed to parse offset: %s", err)
-						return
-					}
-					handler.offsets = offsetsArg
+				offsetsArg, err := parseOffsetFlag(offset)
+				if err != nil && !errors.Is(err, ErrOffsetNotSet) {
+					log.Errorf("Failed to parse offset: %s", err)
+					return
 				}
+				handler.offset = offsetsArg
 
-				err := consumer.Consume(context.Background(), topicsFlag, handler)
+				err = consumer.Consume(context.Background(), topicsFlag, handler)
 
 				if handler.maximumReached() {
 					log.Debugf("Message consuming limit reached: %d", countFlag)
@@ -111,8 +109,7 @@ func NewConsumeCmd() *cobra.Command {
 	flags.StringSliceVarP(&topicsFlag, "topic", "t", []string{}, "Topic to consume from")
 	flags.IntVarP(&countFlag, "count", "c", 0, "Exit after consuming this number of messages")
 	flags.BoolVar(&noCommit, "no-commit", false, "Consume messages without commiting offset")
-	flags.StringSliceVarP(&offsets, "offsets", "o", nil, "Start consuming from this offsets: "+
-		"topic.name1:123,topic.name2:321 (offsets for every topic) or 123 (one global offset for all topics), default: newest)")
+	flags.StringVarP(&offset, "offset", "o", "", "Start consuming from this offset (default: newest))")
 
 	_ = cmd.MarkFlagRequired("group")
 	_ = cmd.MarkFlagRequired("topic")
@@ -120,67 +117,38 @@ func NewConsumeCmd() *cobra.Command {
 	return cmd
 }
 
-const globalOffset = "global"
-
-func parseOffsetsFlag(offsetsFlag []string) (offsets map[string]int64, err error) {
-	offsets = make(map[string]int64, len(offsetsFlag))
-	for _, offset := range offsetsFlag {
-		if offset == "" {
-			continue
-		}
-		i, err := strconv.ParseInt(offset, 10, 64)
-		if err == nil {
-			return map[string]int64{globalOffset: i}, nil
-		}
-
-		topicOffsetPair := strings.Split(offset, ":")
-		if len(topicOffsetPair) != 2 {
-			return nil, fmt.Errorf("%w %s, "+
-				"expected: topic:123 (topic name and offset value) or 123 (global offset value for all topics)", ErrInvalidOffset, offset)
-		}
-		offsetForTopic, err := strconv.ParseInt(topicOffsetPair[1], 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("%w %s, "+
-				"failed to parse offset value: %s\n"+
-				"expected: topic:123 (topic name and offset value) or 123 (global offset value for all topics)\n"+
-				"error: %s", ErrInvalidOffset, topicOffsetPair[1], offset, err)
-		}
-		offsets[topicOffsetPair[0]] = offsetForTopic
+func parseOffsetFlag(offsetsFlag string) (offset int64, err error) {
+	if offsetsFlag == "" {
+		return -1, ErrOffsetNotSet
 	}
-
-	return offsets, nil
+	intOffst, err := strconv.ParseInt(offsetsFlag, 10, 64)
+	if err != nil {
+		return -1, fmt.Errorf("error with offset '%s': %w", offsetsFlag, ErrInvalidOffset)
+	}
+	if intOffst < 0 {
+		return -1, fmt.Errorf("error negative offset '%s': %w", offsetsFlag, ErrInvalidOffset)
+	}
+	return intOffst, nil
 }
 
 type protoHandler struct {
 	desc              *desc.MessageDescriptor
 	MaxCount, counter int
-	topics            []string
+	topic             string
 	partition         int32
-	offsets           map[string]int64
+	offset            int64
 }
 
 var once sync.Once
 
 func (p protoHandler) Setup(sess sarama.ConsumerGroupSession) error {
 	once.Do(func() {
-		goffst, isGlobalOffsetSet := p.offsets[globalOffset]
-		for _, topic := range p.topics {
-			if partFromFlags := flags.Partition; partFromFlags > 0 {
-				p.partition = partFromFlags
-			}
+		if partFromFlags := flags.Partition; partFromFlags > 0 {
+			p.partition = partFromFlags
+		}
 
-			if isGlobalOffsetSet {
-				sess.ResetOffset(topic, p.partition, goffst, "")
-				continue
-			}
-
-			if p.offsets != nil {
-				offset, ok := p.offsets[topic]
-				if !ok {
-					continue
-				}
-				sess.ResetOffset(topic, p.partition, offset, "")
-			}
+		if p.offset >= 0 {
+			sess.ResetOffset(p.topic, p.partition, p.offset, "")
 		}
 	})
 	return nil

--- a/cmd/cmd_consume.go
+++ b/cmd/cmd_consume.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
-
+	"fmt"
 	"github.com/SberMarket-Tech/protokaf/internal/kafka"
 	"github.com/SberMarket-Tech/protokaf/internal/utils/dump"
 	"github.com/Shopify/sarama"
@@ -11,6 +11,9 @@ import (
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 func NewConsumeCmd() *cobra.Command {
@@ -19,6 +22,7 @@ func NewConsumeCmd() *cobra.Command {
 		topicsFlag []string
 		countFlag  int
 		noCommit   bool
+		offsets    []string
 	)
 
 	cmd := &cobra.Command{
@@ -41,6 +45,7 @@ func NewConsumeCmd() *cobra.Command {
 			if noCommit {
 				kafkaConfig.Consumer.Offsets.AutoCommit.Enable = false
 			}
+
 			// consumer
 			consumer, err := kafka.NewConsumerGroup(viper.GetStringSlice("broker"), groupFlag, kafkaConfig)
 			if err != nil {
@@ -58,6 +63,19 @@ func NewConsumeCmd() *cobra.Command {
 				handler := &protoHandler{
 					MaxCount: countFlag,
 					desc:     md,
+
+					topics:    topicsFlag,
+					partition: int32(0),
+				}
+
+				// set offset
+				if offsets != nil {
+					offsetsArg, err := parseOffsetsFlag(offsets)
+					if err != nil {
+						log.Errorf("Failed to parse offset: %s", err)
+						return
+					}
+					handler.offsets = offsetsArg
 				}
 
 				err := consumer.Consume(context.Background(), topicsFlag, handler)
@@ -91,6 +109,8 @@ func NewConsumeCmd() *cobra.Command {
 	flags.StringSliceVarP(&topicsFlag, "topic", "t", []string{}, "Topic to consume from")
 	flags.IntVarP(&countFlag, "count", "c", 0, "Exit after consuming this number of messages")
 	flags.BoolVar(&noCommit, "no-commit", false, "Consume messages without commiting offset")
+	flags.StringSliceVarP(&offsets, "offsets", "o", nil, "Start consuming from this offsets: "+
+		"topic.name1:123,topic.name2:321 (offsets for every topic) or 123 (one global offset for all topics), default: newest)")
 
 	_ = cmd.MarkFlagRequired("group")
 	_ = cmd.MarkFlagRequired("topic")
@@ -98,12 +118,71 @@ func NewConsumeCmd() *cobra.Command {
 	return cmd
 }
 
+const globalOffset = "global"
+
+func parseOffsetsFlag(offsetsFlag []string) (offsets map[string]int64, err error) {
+	offsets = make(map[string]int64, len(offsetsFlag))
+	for _, offset := range offsetsFlag {
+		i, err := strconv.ParseInt(offset, 10, 64)
+		if err == nil {
+			return map[string]int64{globalOffset: i}, nil
+		}
+
+		topicOffsetPair := strings.Split(offset, ":")
+		if len(topicOffsetPair) != 2 {
+			return nil, fmt.Errorf("invalid offset format: %s, "+
+				"expected: topic:123 (topic name and offset value) or 123 (global offset value for all topics)", offset)
+		}
+		offsetForTopic, err := strconv.ParseInt(topicOffsetPair[1], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid offset format: %s, "+
+				"failed to parse offset value: %s\n"+
+				"expected: topic:123 (topic name and offset value) or 123 (global offset value for all topics)\n"+
+				"error: %s", topicOffsetPair[1], offset, err)
+		}
+		offsets[topicOffsetPair[0]] = offsetForTopic
+	}
+
+	return offsets, nil
+}
+
 type protoHandler struct {
 	desc              *desc.MessageDescriptor
 	MaxCount, counter int
+	topics            []string
+	partition         int32
+	offsets           map[string]int64
 }
 
-func (protoHandler) Setup(_ sarama.ConsumerGroupSession) error   { return nil }
+var once sync.Once
+
+func (p protoHandler) Setup(sess sarama.ConsumerGroupSession) error {
+	once.Do(func() {
+		goffst, isGlobalOffsetSet := p.offsets[globalOffset]
+		for _, topic := range p.topics {
+			if partFromFlags := flags.Partition; partFromFlags > 0 {
+				p.partition = partFromFlags
+			}
+
+			if isGlobalOffsetSet {
+				sess.ResetOffset(topic, p.partition, goffst, "")
+				continue
+			}
+
+			if p.offsets != nil {
+				offset, ok := p.offsets[topic]
+				if !ok {
+					println("ok2")
+					continue
+				}
+				println("ok3")
+				sess.ResetOffset(topic, p.partition, offset, "")
+			}
+		}
+	})
+	return nil
+}
+
 func (protoHandler) Cleanup(_ sarama.ConsumerGroupSession) error { return nil }
 
 // ErrMaximumReached error if limit reached

--- a/cmd/cmd_consume.go
+++ b/cmd/cmd_consume.go
@@ -109,7 +109,7 @@ func NewConsumeCmd() *cobra.Command {
 	flags.StringSliceVarP(&topicsFlag, "topic", "t", []string{}, "Topic to consume from")
 	flags.IntVarP(&countFlag, "count", "c", 0, "Exit after consuming this number of messages")
 	flags.BoolVar(&noCommit, "no-commit", false, "Consume messages without commiting offset")
-	flags.StringVarP(&offset, "offset", "o", "", "Start consuming from this offset (default: newest))")
+	flags.StringVarP(&offset, "offset", "o", "", "Start consuming from this offset (default: newest)")
 
 	_ = cmd.MarkFlagRequired("group")
 	_ = cmd.MarkFlagRequired("topic")

--- a/cmd/cmd_consume.go
+++ b/cmd/cmd_consume.go
@@ -172,10 +172,8 @@ func (p protoHandler) Setup(sess sarama.ConsumerGroupSession) error {
 			if p.offsets != nil {
 				offset, ok := p.offsets[topic]
 				if !ok {
-					println("ok2")
 					continue
 				}
-				println("ok3")
 				sess.ResetOffset(topic, p.partition, offset, "")
 			}
 		}

--- a/cmd/cmd_consume_test.go
+++ b/cmd/cmd_consume_test.go
@@ -16,58 +16,27 @@ func Test_NewConsumeCmd_NoTopicFlags(t *testing.T) {
 }
 
 func Test_parseOffsetsFlag(t *testing.T) {
-	t.Run("offsets for multiple topics", func(t *testing.T) {
-		offsets, err := parseOffsetsFlag([]string{"topic1:0", "topic2:1", "topic3:234", "topic4:123"})
+	t.Run("offset happy case", func(t *testing.T) {
+		offset, err := parseOffsetFlag("1")
 		require.Nil(t, err)
-		require.Equal(t, map[string]int64{
-			"topic1": 0,
-			"topic2": 1,
-			"topic3": 234,
-			"topic4": 123,
-		}, offsets)
-	})
-
-	t.Run("global offset", func(t *testing.T) {
-		offsets, err := parseOffsetsFlag([]string{"123"})
-		require.Nil(t, err)
-		require.Equal(t, map[string]int64{
-			globalOffset: 123,
-		}, offsets)
-	})
-
-	t.Run("global offset", func(t *testing.T) {
-		offsets, err := parseOffsetsFlag([]string{"123"})
-		require.Nil(t, err)
-		require.Equal(t, map[string]int64{
-			globalOffset: 123,
-		}, offsets)
-	})
-
-	t.Run("global offset has priority over other definitions", func(t *testing.T) {
-		offsets, err := parseOffsetsFlag([]string{"123", "topic1:123", "topic2:321"})
-		require.Nil(t, err)
-		require.Equal(t, map[string]int64{
-			globalOffset: 123,
-		}, offsets)
+		require.EqualValues(t, 1, offset)
 	})
 
 	t.Run("error when offset is not a number", func(t *testing.T) {
-		v, err := parseOffsetsFlag([]string{"topic1:123", "topic2:abc"})
-		require.Nil(t, v)
+		v, err := parseOffsetFlag("fdgdfg")
 		require.ErrorIs(t, err, ErrInvalidOffset)
+		require.EqualValues(t, -1, v)
 	})
 
-	t.Run("skip empty offset", func(t *testing.T) {
-		v, err := parseOffsetsFlag([]string{""})
-		require.Equal(t, map[string]int64{}, v)
-		require.NoError(t, err)
+	t.Run("error empty offset", func(t *testing.T) {
+		v, err := parseOffsetFlag("")
+		require.ErrorIs(t, err, ErrOffsetNotSet)
+		require.EqualValues(t, -1, v)
+	})
 
-		v, err = parseOffsetsFlag([]string{"", "topic1:123", ""})
-		require.Equal(t, map[string]int64{"topic1": 123}, v)
-		require.NoError(t, err)
-
-		v, err = parseOffsetsFlag(nil)
-		require.Equal(t, map[string]int64{}, v)
-		require.NoError(t, err)
+	t.Run("error negative offset", func(t *testing.T) {
+		v, err := parseOffsetFlag("-1")
+		require.ErrorIs(t, err, ErrInvalidOffset)
+		require.EqualValues(t, -1, v)
 	})
 }

--- a/cmd/cmd_consume_test.go
+++ b/cmd/cmd_consume_test.go
@@ -65,5 +65,9 @@ func Test_parseOffsetsFlag(t *testing.T) {
 		v, err = parseOffsetsFlag([]string{"", "topic1:123", ""})
 		require.Equal(t, map[string]int64{"topic1": 123}, v)
 		require.NoError(t, err)
+
+		v, err = parseOffsetsFlag(nil)
+		require.Equal(t, map[string]int64{}, v)
+		require.NoError(t, err)
 	})
 }

--- a/cmd/cmd_consume_test.go
+++ b/cmd/cmd_consume_test.go
@@ -3,14 +3,67 @@ package cmd
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_NewConsumeCmd_NoTopicFlags(t *testing.T) {
-	cmd := NewProduceCmd()
+	cmd := NewConsumeCmd()
 	cmd.SetArgs([]string{"HelloRequest"})
 
 	_, _, err := getCommandOut(t, cmd)
 
-	assert.Contains(t, err.Error(), `required flag(s) "topic" not set`)
+	require.Contains(t, err.Error(), `required flag(s) "group", "topic" not set`)
+}
+
+func Test_parseOffsetsFlag(t *testing.T) {
+	t.Run("offsets for multiple topics", func(t *testing.T) {
+		offsets, err := parseOffsetsFlag([]string{"topic1:0", "topic2:1", "topic3:234", "topic4:123"})
+		require.Nil(t, err)
+		require.Equal(t, map[string]int64{
+			"topic1": 0,
+			"topic2": 1,
+			"topic3": 234,
+			"topic4": 123,
+		}, offsets)
+	})
+
+	t.Run("global offset", func(t *testing.T) {
+		offsets, err := parseOffsetsFlag([]string{"123"})
+		require.Nil(t, err)
+		require.Equal(t, map[string]int64{
+			globalOffset: 123,
+		}, offsets)
+	})
+
+	t.Run("global offset", func(t *testing.T) {
+		offsets, err := parseOffsetsFlag([]string{"123"})
+		require.Nil(t, err)
+		require.Equal(t, map[string]int64{
+			globalOffset: 123,
+		}, offsets)
+	})
+
+	t.Run("global offset has priority over other definitions", func(t *testing.T) {
+		offsets, err := parseOffsetsFlag([]string{"123", "topic1:123", "topic2:321"})
+		require.Nil(t, err)
+		require.Equal(t, map[string]int64{
+			globalOffset: 123,
+		}, offsets)
+	})
+
+	t.Run("error when offset is not a number", func(t *testing.T) {
+		v, err := parseOffsetsFlag([]string{"topic1:123", "topic2:abc"})
+		require.Nil(t, v)
+		require.ErrorIs(t, err, ErrInvalidOffset)
+	})
+
+	t.Run("skip empty offset", func(t *testing.T) {
+		v, err := parseOffsetsFlag([]string{""})
+		require.Equal(t, map[string]int64{}, v)
+		require.NoError(t, err)
+
+		v, err = parseOffsetsFlag([]string{"", "topic1:123", ""})
+		require.Equal(t, map[string]int64{"topic1": 123}, v)
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
Related to https://github.com/SberMarket-Tech/protokaf/issues/9

This pull request will allow for doing such things:
```
$ protokaf consume HelloRequest -G mygroup -t test -o 5 (which means "read topic from 5 offset")
```